### PR TITLE
Fix dependencies

### DIFF
--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -27,8 +27,8 @@ class Qt < Formula
 
   depends_on "pkg-config" => :build
   depends_on :xcode => :build
-  depends_on :mysql => :optional
-  depends_on :postgresql => :optional
+  depends_on "mysql" => :optional
+  depends_on "postgresql" => :optional
 
   # Restore `.pc` files for framework-based build of Qt 5 on OS X. This
   # partially reverts <https://codereview.qt-project.org/#/c/140954/> merged


### PR DESCRIPTION
Dependencies on other formulas are done by using strings now, while symbol dependencies are used solely for built in system level dependencies.