### PR TITLE
qt 5.11 / qtwebkit latest

### DIFF
--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -3,42 +3,35 @@
 class Qt < Formula
   desc "Cross-platform application and UI framework"
   homepage "https://www.qt.io/"
-  url "https://dl.bintray.com/homebrew/mirror/qt-5.10.1.tar.xz"
-  mirror "https://download.qt.io/official_releases/qt/5.10/5.10.1/single/qt-everywhere-src-5.10.1.tar.xz"
-  mirror "https://www.mirrorservice.org/sites/download.qt-project.org/official_releases/qt/5.10/5.10.1/single/qt-everywhere-src-5.10.1.tar.xz"
-  sha256 "05ffba7b811b854ed558abf2be2ddbd3bb6ddd0b60ea4b5da75d277ac15e740a"
-  head "https://code.qt.io/qt/qt5.git", :branch => "5.10", :shallow => false
+  url "https://download.qt.io/official_releases/qt/5.11/5.11.1/single/qt-everywhere-src-5.11.1.tar.xz"
+  mirror "https://qt.mirror.constant.com/archive/qt/5.11/5.11.1/single/qt-everywhere-src-5.11.1.tar.xz"
+  mirror "http://qt.mirrors.tds.net/qt/archive/qt/5.11/5.11.1/single/qt-everywhere-src-5.11.1.tar.xz"
+  sha256 "39602cb08f9c96867910c375d783eed00fc4a244bffaa93b801225d17950fb2b"
+  head "https://code.qt.io/qt/qt5.git", :branch => "5.11", :shallow => false
 
   bottle do
-    sha256 "8b4bad005596a5f8790150fe455db998ac2406f4e0f04140d6656205d844d266" => :high_sierra
-    sha256 "9c488554935fb573554a4e36d36d3c81e47245b7fefc4b61edef894e67ba1740" => :sierra
-    sha256 "c0407afba5951df6cc4c6f6c1c315972bd41c99cecb4e029919c4c15ab6f7bdc" => :el_capitan
+    root_url "https://movableink-homebrew-formulas.s3.amazonaws.com"
+    sha256 "6483de8b8724673a06e03abfc667286c5c660c74b93458f2f9b0cee11da91782" => :high_sierra
   end
 
   keg_only "Qt 5 has CMake issues when linked"
 
-  option "with-docs", "Build documentation"
   option "with-examples", "Build examples"
   option "without-proprietary-codecs", "Don't build with proprietary codecs (e.g. mp3)"
 
-  # OS X 10.7 Lion is still supported in Qt 5.5, but is no longer a reference
-  # configuration and thus untested in practice. Builds on OS X 10.7 have been
-  # reported to fail: <https://github.com/Homebrew/homebrew/issues/45284>.
-  depends_on :macos => :mountain_lion
+  deprecated_option "with-mysql" => "with-mysql-client"
 
   depends_on "pkg-config" => :build
   depends_on :xcode => :build
-  depends_on "mysql" => :optional
+  depends_on "mysql-client" => :optional
   depends_on "postgresql" => :optional
 
-  # Restore `.pc` files for framework-based build of Qt 5 on OS X. This
-  # partially reverts <https://codereview.qt-project.org/#/c/140954/> merged
-  # between the 5.5.1 and 5.6.0 releases. (Remove this as soon as feasible!)
-  #
+  # Restore `.pc` files for framework-based build of Qt 5 on macOS, partially
+  # reverting <https://codereview.qt-project.org/#/c/140954/>
   # Core formulae known to fail without this patch (as of 2016-10-15):
-  #   * gnuplot  (with `--with-qt` option)
+  #   * gnuplot (with `--with-qt` option)
   #   * mkvtoolnix (with `--with-qt` option, silent build failure)
-  #   * poppler    (with `--with-qt` option)
+  #   * poppler (with `--with-qt` option)
   patch do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/e8fe6567/qt5/restore-pc-files.patch"
     sha256 "48ff18be2f4050de7288bddbae7f47e949512ac4bcd126c2f504be2ac701158b"
@@ -63,7 +56,7 @@ class Qt < Formula
 
     args << "-nomake" << "examples" if build.without? "examples"
 
-    if build.with? "mysql"
+    if build.with? "mysql-client"
       args << "-plugin-sql-mysql"
       (buildpath/"brew_shim/mysql_config").write <<~EOS
         #!/bin/sh
@@ -85,11 +78,6 @@ class Qt < Formula
     ENV.deparallelize
     system "make", "install"
 
-    if build.with? "docs"
-      system "make", "docs"
-      system "make", "install_docs"
-    end
-
     # Some config scripts will only find Qt in a "Frameworks" folder
     frameworks.install_symlink Dir["#{lib}/*.framework"]
 
@@ -109,9 +97,9 @@ class Qt < Formula
   end
 
   def caveats; <<~EOS
-    We agreed to the Qt opensource license for you.
+    We agreed to the Qt open source license for you.
     If this is unacceptable you should uninstall.
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -3,22 +3,23 @@
 class Qt < Formula
   desc "Cross-platform application and UI framework"
   homepage "https://www.qt.io/"
-  url "https://download.qt.io/official_releases/qt/5.9/5.9.3/single/qt-everywhere-opensource-src-5.9.3.tar.xz"
-  mirror "https://www.mirrorservice.org/sites/download.qt-project.org/official_releases/qt/5.9/5.9.3/single/qt-everywhere-opensource-src-5.9.3.tar.xz"
-  sha256 "57acd8f03f830c2d7dc29fbe28aaa96781b2b9bdddce94196e6761a0f88c6046"
-  head "https://code.qt.io/qt/qt5.git", :branch => "5.9", :shallow => false
+  url "https://dl.bintray.com/homebrew/mirror/qt-5.10.1.tar.xz"
+  mirror "https://download.qt.io/official_releases/qt/5.10/5.10.1/single/qt-everywhere-src-5.10.1.tar.xz"
+  mirror "https://www.mirrorservice.org/sites/download.qt-project.org/official_releases/qt/5.10/5.10.1/single/qt-everywhere-src-5.10.1.tar.xz"
+  sha256 "05ffba7b811b854ed558abf2be2ddbd3bb6ddd0b60ea4b5da75d277ac15e740a"
+  head "https://code.qt.io/qt/qt5.git", :branch => "5.10", :shallow => false
 
   bottle do
-    root_url "https://movableink-homebrew-formulas.s3.amazonaws.com"
-    sha256 "570ca1b244dbcecc74d2b7813e5659024eba1500640c84b1b6eedcd96dd1ba6f" => :high_sierra
-    sha256 "a05e2f102433b8e0eee1c8cbd0f27949c9314f7ebf237766bcf191ffdb4b6940" => :sierra
-    sha256 "42eae12f322119d24b695fdb29678b50b020dfde0a24bdd8caf4a952649ac2d0" => :el_capitan
+    sha256 "8b4bad005596a5f8790150fe455db998ac2406f4e0f04140d6656205d844d266" => :high_sierra
+    sha256 "9c488554935fb573554a4e36d36d3c81e47245b7fefc4b61edef894e67ba1740" => :sierra
+    sha256 "c0407afba5951df6cc4c6f6c1c315972bd41c99cecb4e029919c4c15ab6f7bdc" => :el_capitan
   end
 
   keg_only "Qt 5 has CMake issues when linked"
 
   option "with-docs", "Build documentation"
   option "with-examples", "Build examples"
+  option "without-proprietary-codecs", "Don't build with proprietary codecs (e.g. mp3)"
 
   # OS X 10.7 Lion is still supported in Qt 5.5, but is no longer a reference
   # configuration and thus untested in practice. Builds on OS X 10.7 have been
@@ -27,8 +28,8 @@ class Qt < Formula
 
   depends_on "pkg-config" => :build
   depends_on :xcode => :build
-  depends_on :mysql => :optional
-  depends_on :postgresql => :optional
+  depends_on "mysql" => :optional
+  depends_on "postgresql" => :optional
 
   # Restore `.pc` files for framework-based build of Qt 5 on OS X. This
   # partially reverts <https://codereview.qt-project.org/#/c/140954/> merged
@@ -41,15 +42,6 @@ class Qt < Formula
   patch do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/e8fe6567/qt5/restore-pc-files.patch"
     sha256 "48ff18be2f4050de7288bddbae7f47e949512ac4bcd126c2f504be2ac701158b"
-  end
-
-  # Remove for >= 5.10
-  # Fix for upstream issue "macdeployqt does not work with Homebrew"
-  # See https://bugreports.qt.io/browse/QTBUG-56814
-  # Upstream commit from 23 Dec 2016 https://github.com/qt/qttools/commit/8f9b747f030bb41556831a23ec2a8e7e76fb7dc0#diff-2b6e250f93810fd9bcf9bbecf5d2be88
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/a627e0a/qt5/QTBUG-56814.patch"
-    sha256 "b18e4715fcef2992f051790d3784a54900508c93350c25b0f2228cb058567142"
   end
 
   def install
@@ -86,6 +78,7 @@ class Qt < Formula
     end
 
     args << "-plugin-sql-psql" if build.with? "postgresql"
+    args << "-proprietary-codecs" if build.with? "proprietary-codecs"
 
     system "./configure", *args
     system "make"

--- a/Formula/qtwebkit.rb
+++ b/Formula/qtwebkit.rb
@@ -1,11 +1,11 @@
 class Qtwebkit < Formula
   desc "Full-featured qt port of the WebKit rendering engine"
-  homepage "https://github.com/annulen/webkit"
+  homepage "https://github.com/movableink/webkit"
   url "https://github.com/annulen/webkit/releases/download/qtwebkit-tp4/qtwebkit-tp4.tar.xz"
   sha256 "35fcf7e04742b040a072245d79f36d1486e63345a69f53e09408c6564d3bcf27"
   revision 1
-  version "HEAD-3777b4f"
-  head "https://github.com/annulen/webkit.git", :branch => "qtwebkit-stable"
+  version "HEAD-c0e9b56"
+  head "https://github.com/movableink/webkit.git", :branch => "macos-include-dir"
 
   depends_on "cmake" => :build
   depends_on "ninja" => [:build, :optional]
@@ -18,13 +18,7 @@ class Qtwebkit < Formula
   bottle do
     root_url "https://movableink-homebrew-formulas.s3.amazonaws.com"
     cellar :any
-    rebuild 2
-    sha256 "f5f433ee6652eaa09a52708987fe4c1b831c12f5f75cac51ef6f308317462fb0" => :high_sierra
-  end
-
-  patch do
-    url "https://gist.githubusercontent.com/mnutt/8a0ae505e13ee89d571036d67a56bf9e/raw/c95d2777b138a11af330fac83c03bede276169de/mac_framework_includes.patch"
-    sha256 "6933e62d45bbc6cfc38a7ec376637f300226768c94c91b268555b843cf429c8e"
+    sha256 "b6c1a5f275e9bc2a945a97c0c00c88c4fb709c156d44f423893fa1dbc78db446" => :high_sierra
   end
 
   def install


### PR DESCRIPTION
Updates qt to `5.11.1`, and updates qtwebkit to latest https://github.com/movableink/webkit, which includes some extra apis not in standard qtwebkit.