### PR TITLE
Change nsq version to match production (0.2.31)

### DIFF
--- a/Formula/nsq.rb
+++ b/Formula/nsq.rb
@@ -1,8 +1,8 @@
 class Nsq < Formula
   desc "Realtime distributed messaging platform"
   homepage "https://nsq.io/"
-  url "https://github.com/nsqio/nsq/archive/v0.3.8.tar.gz"
-  sha256 "d9107cdfe218523a74ee801caaa97968becb4b82dae7085dbb52d05c25028ff3"
+  url "https://github.com/nsqio/nsq/releases/download/v0.2.31/nsq-0.2.31.darwin-amd64.go1.3.1.tar.gz"
+  sha256 "ffc40ac7e7bf70de08bf8783aeb662b3aa974b16f4417f21a0fc16d5582724e8"
   head "https://github.com/nsqio/nsq.git"
 
   bottle do
@@ -13,17 +13,17 @@ class Nsq < Formula
     sha256 "02225f180c8e5ebc9d5e0ecd30c0875738b10904143c031a07709a6661362243" => :el_capitan
   end
 
-  depends_on "gpm" => :build
-  depends_on "go" => :build
-
   def install
-    ENV["GOPATH"] = buildpath
-    (buildpath/"src/github.com/nsqio/nsq").install buildpath.children
-    cd "src/github.com/nsqio/nsq" do
-      system "gpm", "install"
-      system "make", "DESTDIR=#{prefix}", "PREFIX=", "install"
-      prefix.install_metafiles
-    end
+    bin.install "#{buildpath}/bin/nsqlookupd"
+    bin.install "#{buildpath}/bin/nsqd"
+	bin.install "#{buildpath}/bin/nsqadmin"
+	bin.install "#{buildpath}/bin/nsq_pubsub"
+	bin.install "#{buildpath}/bin/nsq_to_nsq"
+	bin.install "#{buildpath}/bin/nsq_to_file"
+	bin.install "#{buildpath}/bin/nsq_to_http"
+	bin.install "#{buildpath}/bin/nsq_tail"
+	bin.install "#{buildpath}/bin/nsq_stat"
+	bin.install "#{buildpath}/bin/to_nsq"
   end
 
   def post_install

--- a/Formula/nsq.rb
+++ b/Formula/nsq.rb
@@ -5,14 +5,6 @@ class Nsq < Formula
   sha256 "ffc40ac7e7bf70de08bf8783aeb662b3aa974b16f4417f21a0fc16d5582724e8"
   head "https://github.com/nsqio/nsq.git"
 
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "2fa867147f43fa78509dc153f725c5e3325a1a268500811db2dfe5d90db6b823" => :mojave
-    sha256 "ff5ee1076510935d467a359172c57a487f5c4fa50537c28643f60b6254d60348" => :high_sierra
-    sha256 "e06823b1c505fff73402522d13a74f386106987c96c83dcccb0b8e68e169449a" => :sierra
-    sha256 "02225f180c8e5ebc9d5e0ecd30c0875738b10904143c031a07709a6661362243" => :el_capitan
-  end
-
   def install
     bin.install "#{buildpath}/bin/nsqlookupd"
     bin.install "#{buildpath}/bin/nsqd"


### PR DESCRIPTION
[ch28047]

The current homebrew formula installs  nsq0.3.8. We're using
nsq0.2.31 is production, so we should use it in our dev
environments.

The new formula does not build nsq from source because the 
dependency tools used to build this repo are very out of date
and generally difficult to get to behave considering homebrew's
lack of comprehensive versioning.
Instead, this formula just pulls the precompiled binaries for darwin
from github.