### PR TITLE
Build nsq from source

### DIFF
--- a/Formula/nsq.rb
+++ b/Formula/nsq.rb
@@ -1,21 +1,27 @@
 class Nsq < Formula
   desc "Realtime distributed messaging platform"
   homepage "https://nsq.io/"
-  url "https://github.com/nsqio/nsq/releases/download/v0.2.31/nsq-0.2.31.darwin-amd64.go1.3.1.tar.gz"
-  sha256 "ffc40ac7e7bf70de08bf8783aeb662b3aa974b16f4417f21a0fc16d5582724e8"
+  #url "https://github.com/nsqio/nsq/releases/download/v0.2.31/nsq-0.2.31.darwin-amd64.go1.3.1.tar.gz"
+  #version "0.2.31"
+  #sha256 "ffc40ac7e7bf70de08bf8783aeb662b3aa974b16f4417f21a0fc16d5582724e8"
+  url "https://github.com/nsqio/nsq/archive/v0.2.31.tar.gz"
+  sha256 "66a8431ab169d661b547afa77fc7355dac7d955f259a937ed6b423b9ebadefac"
   head "https://github.com/nsqio/nsq.git"
 
+  depends_on "go" => :build
+  depends_on "dep" => :build
+
   def install
-    bin.install "#{buildpath}/bin/nsqlookupd"
-    bin.install "#{buildpath}/bin/nsqd"
-	bin.install "#{buildpath}/bin/nsqadmin"
-	bin.install "#{buildpath}/bin/nsq_pubsub"
-	bin.install "#{buildpath}/bin/nsq_to_nsq"
-	bin.install "#{buildpath}/bin/nsq_to_file"
-	bin.install "#{buildpath}/bin/nsq_to_http"
-	bin.install "#{buildpath}/bin/nsq_tail"
-	bin.install "#{buildpath}/bin/nsq_stat"
-	bin.install "#{buildpath}/bin/to_nsq"
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/bitly/nsq").install buildpath.children
+
+    cd "src/github.com/bitly/nsq" do
+      system "dep", "init"
+      system "dep", "ensure"
+      system "make", "DESTDIR=#{prefix}", "PREFIX=", "all"
+      system "make", "DESTDIR=#{prefix}", "PREFIX=", "install"
+      prefix.install_metafiles
+    end
   end
 
   def post_install

--- a/Formula/nsq.rb
+++ b/Formula/nsq.rb
@@ -16,8 +16,13 @@ class Nsq < Formula
     (buildpath/"src/github.com/bitly/nsq").install buildpath.children
 
     cd "src/github.com/bitly/nsq" do
+      system "mv", "Godeps", "tmp"
+      system "mkdir", "Godeps"
+      system "mv", "tmp", "Godeps/Godeps.json"
+
       system "dep", "init"
       system "dep", "ensure"
+
       system "make", "DESTDIR=#{prefix}", "PREFIX=", "all"
       system "make", "DESTDIR=#{prefix}", "PREFIX=", "install"
       prefix.install_metafiles


### PR DESCRIPTION
[ch28047]

Running the pre-compiled binaries on newer versions of macOS
causes nsq to panic, so we're preferring to build from source
with the latest version of go (the pre-compiled binaries are
built with go1.3.1).