### PR TITLE
Fix the bin path for installs and the checksum

### DIFF
--- a/Formula/nsq.rb
+++ b/Formula/nsq.rb
@@ -2,7 +2,7 @@ class Nsq < Formula
   desc "Realtime distributed messaging platform"
   homepage "https://nsq.io/"
   url "https://movableink-developer-binaries.s3-us-west-2.amazonaws.com/nsq_0.3.8_darwin.zip"
-  sha256 "92067e42af27b8a15e5f037e2cb9014858ec369140ce76b5aedd563bf1c2ccf8"
+  sha256 "7ac121e06df0a08b63b646064ec6710ee70e9bde89272ef502ea9b5ae8039bc6"
 
   depends_on "movableink/formulas/nsqadmin"
   depends_on "movableink/formulas/nsqd"

--- a/Formula/nsqadmin.rb
+++ b/Formula/nsqadmin.rb
@@ -2,10 +2,10 @@ class Nsqadmin < Formula
   desc "Admin UI for NSQ"
   homepage "https://nsq.io"
   url "https://movableink-developer-binaries.s3-us-west-2.amazonaws.com/nsq_0.3.8_darwin.zip"
-  sha256 "92067e42af27b8a15e5f037e2cb9014858ec369140ce76b5aedd563bf1c2ccf8"
+  sha256 "7ac121e06df0a08b63b646064ec6710ee70e9bde89272ef502ea9b5ae8039bc6"
 
   def install
-    bin.install "#{buildpath}/bin/nsqadmin"
+    bin.install "#{buildpath}/nsqadmin"
   end
 
   plist_options :startup => true

--- a/Formula/nsqd.rb
+++ b/Formula/nsqd.rb
@@ -2,10 +2,10 @@ class Nsqd < Formula
   desc "Message queueing daemon for NSQ"
   homepage "https://nsq.io"
   url "https://movableink-developer-binaries.s3-us-west-2.amazonaws.com/nsq_0.3.8_darwin.zip"
-  sha256 "92067e42af27b8a15e5f037e2cb9014858ec369140ce76b5aedd563bf1c2ccf8"
+  sha256 "7ac121e06df0a08b63b646064ec6710ee70e9bde89272ef502ea9b5ae8039bc6"
 
   def install
-    bin.install "#{buildpath}/bin/nsqd"
+    bin.install "#{buildpath}/nsqd"
 
     mkdir "#{var}/nsq"
   end

--- a/Formula/nsqlookupd.rb
+++ b/Formula/nsqlookupd.rb
@@ -2,10 +2,10 @@ class Nsqlookupd < Formula
   desc "Topology daemon for NSQ"
   homepage "https://nsq.io"
   url "https://movableink-developer-binaries.s3-us-west-2.amazonaws.com/nsq_0.3.8_darwin.zip"
-  sha256 "92067e42af27b8a15e5f037e2cb9014858ec369140ce76b5aedd563bf1c2ccf8"
+  sha256 "7ac121e06df0a08b63b646064ec6710ee70e9bde89272ef502ea9b5ae8039bc6"
 
   def install
-    bin.install "#{buildpath}/bin/nsqlookupd"
+    bin.install "#{buildpath}/nsqlookupd"
   end
 
   plist_options :startup => true

--- a/Formula/nsqutils.rb
+++ b/Formula/nsqutils.rb
@@ -2,11 +2,11 @@ class Nsqutils < Formula
   desc "Utilities for NSQ"
   homepage "https://nsq.io"
   url "https://movableink-developer-binaries.s3-us-west-2.amazonaws.com/nsq_0.3.8_darwin.zip"
-  sha256 "92067e42af27b8a15e5f037e2cb9014858ec369140ce76b5aedd563bf1c2ccf8"
+  sha256 "7ac121e06df0a08b63b646064ec6710ee70e9bde89272ef502ea9b5ae8039bc6"
 
   def install
-    bin.install Dir["#{buildpath}/bin/nsq_*"]
-    bin.install "#{buildpath}/bin/to_nsq"
+    bin.install Dir["#{buildpath}/nsq_*"]
+    bin.install "#{buildpath}/to_nsq"
   end
 
   test do


### PR DESCRIPTION
[ch29569]

Fix the checksums so that they match the S3 file, and also remove the extra `bin` from the directory install path, since `buildpath` already has it.