### PR TITLE
Allow for any java with spark, since spark just needs java 8+

### DIFF
--- a/Formula/apache-spark.rb
+++ b/Formula/apache-spark.rb
@@ -8,7 +8,7 @@ class ApacheSpark < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.8"
+  depends_on "openjdk"
 
   def install
     # Rename beeline to distinguish it from hive's beeline


### PR DESCRIPTION
This was throwing an error for _any_ usage of the movableink tap.