### PR TITLE
Move sha tags to keys rather than values

### DIFF
--- a/Formula/gdal.rb
+++ b/Formula/gdal.rb
@@ -7,9 +7,9 @@ class Gdal < Formula
 
   bottle do
     root_url "https://homebrew.bintray.com/bottles"
-    sha256 "448a4cc4dde65b98bae3abaa94e7a037d95cc002ba12e9dc5fd56ed21b7b7a3e" => :mojave
-    sha256 "322f5c80ead8cda7e2466099c5e1fb6306901646234a457cdfe1b8f14e5ebf22" => :high_sierra
-    sha256 "2430ac950db9240c1548d94d410c015c202f30dd10985c229f43c1dda6032966" => :sierra
+    sha256 mojave:      "448a4cc4dde65b98bae3abaa94e7a037d95cc002ba12e9dc5fd56ed21b7b7a3e"
+    sha256 high_sierra: "322f5c80ead8cda7e2466099c5e1fb6306901646234a457cdfe1b8f14e5ebf22"
+    sha256 sierra:      "2430ac950db9240c1548d94d410c015c202f30dd10985c229f43c1dda6032966"
   end
 
   head do

--- a/Formula/postgis.rb
+++ b/Formula/postgis.rb
@@ -6,9 +6,8 @@ class Postgis < Formula
 
   bottle do
     root_url "https://movableink-homebrew-formulas.s3.amazonaws.com"
-    cellar :any
     rebuild 3
-    sha256 "307c893d91d359d4df67c8f76379bd9cac344412e061076fb0699ba894ce12b8" => :mojave
+    sha256 cellar: :any, mojave: "307c893d91d359d4df67c8f76379bd9cac344412e061076fb0699ba894ce12b8"
   end
 
   head do

--- a/Formula/postgresql.rb
+++ b/Formula/postgresql.rb
@@ -7,7 +7,7 @@ class Postgresql < Formula
   bottle do
     root_url "https://movableink-homebrew-formulas.s3.amazonaws.com"
     rebuild 3
-    sha256 "8bdc910e5cb9f0562721d2a2a0f7029f18c10647639dfc9843842dafa6498880" => :mojave
+    sha256 mojave: "8bdc910e5cb9f0562721d2a2a0f7029f18c10647639dfc9843842dafa6498880"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -11,7 +11,7 @@ class Qt < Formula
 
   bottle do
     root_url "https://movableink-homebrew-formulas.s3.amazonaws.com"
-    sha256 "6483de8b8724673a06e03abfc667286c5c660c74b93458f2f9b0cee11da91782" => :high_sierra
+    sha256 high_sierra: "6483de8b8724673a06e03abfc667286c5c660c74b93458f2f9b0cee11da91782"
   end
 
   keg_only "Qt 5 has CMake issues when linked"

--- a/Formula/qtwebkit.rb
+++ b/Formula/qtwebkit.rb
@@ -17,8 +17,7 @@ class Qtwebkit < Formula
 
   bottle do
     root_url "https://movableink-homebrew-formulas.s3.amazonaws.com"
-    cellar :any
-    sha256 "b6c1a5f275e9bc2a945a97c0c00c88c4fb709c156d44f423893fa1dbc78db446" => :high_sierra
+    sha256 cellar: :any, high_sierra: "b6c1a5f275e9bc2a945a97c0c00c88c4fb709c156d44f423893fa1dbc78db446"
   end
 
   def install


### PR DESCRIPTION
@frodopwns received the following error when trying to install our tap
```
beagle-delta git:(master) brew install movableink/formulas/nsq
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/core).
==> Updated Formulae
Updated 1 formula.
==> Tapping movableink/formulas
Cloning into '/usr/local/Homebrew/Library/Taps/movableink/homebrew-formulas'...
remote: Enumerating objects: 215, done.
remote: Counting objects: 100% (5/5), done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 215 (delta 1), reused 1 (delta 0), pack-reused 210
Receiving objects: 100% (215/215), 3.80 MiB | 8.00 MiB/s, done.
Resolving deltas: 100% (74/74), done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/movableink/homebrew-formulas/Formula/gdal.rb
gdal: Calling `sha256 "digest" => :tag` in a bottle block is disabled! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
Please report this issue to the movableink/formulas tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/movableink/homebrew-formulas/Formula/gdal.rb:10
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/movableink/homebrew-formulas/Formula/qtwebkit.rb
qtwebkit: Calling `cellar` in a bottle block is disabled! Use `brew style --fix` on the formula to update the style or use `sha256` with a `cellar:` argument instead.
Please report this issue to the movableink/formulas tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/movableink/homebrew-formulas/Formula/qtwebkit.rb:20
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/movableink/homebrew-formulas/Formula/qt.rb
qt: Calling `sha256 "digest" => :tag` in a bottle block is disabled! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
Please report this issue to the movableink/formulas tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/movableink/homebrew-formulas/Formula/qt.rb:14
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/movableink/homebrew-formulas/Formula/postgis.rb
postgis: Calling `cellar` in a bottle block is disabled! Use `brew style --fix` on the formula to update the style or use `sha256` with a `cellar:` argument instead.
Please report this issue to the movableink/formulas tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/movableink/homebrew-formulas/Formula/postgis.rb:9
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/movableink/homebrew-formulas/Formula/postgresql.rb
postgresql: Calling `sha256 "digest" => :tag` in a bottle block is disabled! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
Please report this issue to the movableink/formulas tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/movableink/homebrew-formulas/Formula/postgresql.rb:10
Error: Cannot tap movableink/formulas: invalid syntax in tap!
```

----

Running `brew style --fix /usr/local/Homebrew/Library/Taps/movableink/` updated several other lines as well, but I've decided not to include those changes in this PR since it was several changes (though all looked like equivalent code).
```diff
diff --git a/Formula/apache-spark.rb b/Formula/apache-spark.rb
index 2c9adef..9f539af 100644
--- a/Formula/apache-spark.rb
+++ b/Formula/apache-spark.rb
@@ -21,6 +21,7 @@ class ApacheSpark < Formula
   end
 
   test do
-    assert_match "Long = 1000", pipe_output(bin/"spark-shell --conf spark.driver.bindAddress=127.0.0.1", "sc.parallelize(1 to 1000).count()")
+    assert_match "Long = 1000",
+pipe_output(bin/"spark-shell --conf spark.driver.bindAddress=127.0.0.1", "sc.parallelize(1 to 1000).count()")
   end
 end
diff --git a/Formula/nsq.rb b/Formula/nsq.rb
index 6e41a33..e91f16f 100644
--- a/Formula/nsq.rb
+++ b/Formula/nsq.rb
@@ -10,7 +10,7 @@ class Nsq < Formula
   depends_on "movableink/formulas/nsqutils"
 
   def install
-    mkdir "#{bin}"
+    mkdir bin.to_s
   end
 
   test do
diff --git a/Formula/nsqadmin.rb b/Formula/nsqadmin.rb
index 89128f3..08e9acd 100644
--- a/Formula/nsqadmin.rb
+++ b/Formula/nsqadmin.rb
@@ -8,33 +8,34 @@ class Nsqadmin < Formula
     bin.install "#{buildpath}/nsqadmin"
   end
 
-  plist_options :startup => true
+  plist_options startup: true
 
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>KeepAlive</key>
-        <true/>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{bin}/nsqadmin</string>
-          <string>-lookupd-http-address=127.0.0.1:4161</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>WorkingDirectory</key>
-        <string>#{var}</string>
-        <key>StandardErrorPath</key>
-        <string>#{var}/log/nsqadmin.log</string>
-        <key>StandardOutPath</key>
-        <string>#{var}/log/nsqadmin.log</string>
-      </dict>
-    </plist>
-  EOS
+  def plist
+    <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+          <key>KeepAlive</key>
+          <true/>
+          <key>Label</key>
+          <string>#{plist_name}</string>
+          <key>ProgramArguments</key>
+          <array>
+            <string>#{bin}/nsqadmin</string>
+            <string>-lookupd-http-address=127.0.0.1:4161</string>
+          </array>
+          <key>RunAtLoad</key>
+          <true/>
+          <key>WorkingDirectory</key>
+          <string>#{var}</string>
+          <key>StandardErrorPath</key>
+          <string>#{var}/log/nsqadmin.log</string>
+          <key>StandardOutPath</key>
+          <string>#{var}/log/nsqadmin.log</string>
+        </dict>
+      </plist>
+    EOS
   end
 
   test do
diff --git a/Formula/nsqd.rb b/Formula/nsqd.rb
index 8890d4a..75ef85e 100644
--- a/Formula/nsqd.rb
+++ b/Formula/nsqd.rb
@@ -10,35 +10,36 @@ class Nsqd < Formula
     mkdir "#{var}/nsq"
   end
 
-  plist_options :startup => true
+  plist_options startup: true
 
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>KeepAlive</key>
-        <true/>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{bin}/nsqd</string>
-          <string>-data-path=#{var}/nsq</string>
-          <string>-broadcast-address=localhost</string>
-          <string>-lookupd-tcp-address=127.0.0.1:4160</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>WorkingDirectory</key>
-        <string>#{var}</string>
-        <key>StandardErrorPath</key>
-        <string>#{var}/log/nsqd.log</string>
-        <key>StandardOutPath</key>
-        <string>#{var}/log/nsqd.log</string>
-      </dict>
-    </plist>
-  EOS
+  def plist
+    <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+          <key>KeepAlive</key>
+          <true/>
+          <key>Label</key>
+          <string>#{plist_name}</string>
+          <key>ProgramArguments</key>
+          <array>
+            <string>#{bin}/nsqd</string>
+            <string>-data-path=#{var}/nsq</string>
+            <string>-broadcast-address=localhost</string>
+            <string>-lookupd-tcp-address=127.0.0.1:4160</string>
+          </array>
+          <key>RunAtLoad</key>
+          <true/>
+          <key>WorkingDirectory</key>
+          <string>#{var}</string>
+          <key>StandardErrorPath</key>
+          <string>#{var}/log/nsqd.log</string>
+          <key>StandardOutPath</key>
+          <string>#{var}/log/nsqd.log</string>
+        </dict>
+      </plist>
+    EOS
   end
 
   test do
diff --git a/Formula/nsqlookupd.rb b/Formula/nsqlookupd.rb
index 45fab74..7f73142 100644
--- a/Formula/nsqlookupd.rb
+++ b/Formula/nsqlookupd.rb
@@ -8,32 +8,33 @@ class Nsqlookupd < Formula
     bin.install "#{buildpath}/nsqlookupd"
   end
 
-  plist_options :startup => true
+  plist_options startup: true
 
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>KeepAlive</key>
-        <true/>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{bin}/nsqlookupd</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>WorkingDirectory</key>
-        <string>#{var}</string>
-        <key>StandardErrorPath</key>
-        <string>#{var}/log/nsqlookupd.log</string>
-        <key>StandardOutPath</key>
-        <string>#{var}/log/nsqlookupd.log</string>
-      </dict>
-    </plist>
-  EOS
+  def plist
+    <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+          <key>KeepAlive</key>
+          <true/>
+          <key>Label</key>
+          <string>#{plist_name}</string>
+          <key>ProgramArguments</key>
+          <array>
+            <string>#{bin}/nsqlookupd</string>
+          </array>
+          <key>RunAtLoad</key>
+          <true/>
+          <key>WorkingDirectory</key>
+          <string>#{var}</string>
+          <key>StandardErrorPath</key>
+          <string>#{var}/log/nsqlookupd.log</string>
+          <key>StandardOutPath</key>
+          <string>#{var}/log/nsqlookupd.log</string>
+        </dict>
+      </plist>
+    EOS
   end
 
   test do
diff --git a/Formula/postgis.rb b/Formula/postgis.rb
index f4f1f88..2429802 100644
--- a/Formula/postgis.rb
+++ b/Formula/postgis.rb
@@ -20,11 +20,11 @@ class Postgis < Formula
 
   depends_on "gpp" => :build
   depends_on "pkg-config" => :build
-  depends_on "movableink/formulas/gdal" # for GeoJSON and raster handling
   depends_on "geos"
-  depends_on "json-c" # for GeoJSON and raster handling
-  depends_on "pcre"
+  depends_on "json-c"
+  depends_on "movableink/formulas/gdal" # for GeoJSON and raster handling # for GeoJSON and raster handling
   depends_on "movableink/formulas/postgresql"
+  depends_on "pcre"
   depends_on "proj"
   depends_on "sfcgal" # for advanced 2D/3D functions
 
@@ -106,7 +106,7 @@ class Postgis < Formula
       igAAABI=
     EOS
     result = shell_output("#{bin}/shp2pgsql #{testpath}/brew.shp")
-    assert_match /Point/, result
-    assert_match /AddGeometryColumn/, result
+    assert_match(/Point/, result)
+    assert_match(/AddGeometryColumn/, result)
   end
 end
diff --git a/Formula/postgresql.rb b/Formula/postgresql.rb
index 56eb07b..fbcd2be 100644
--- a/Formula/postgresql.rb
+++ b/Formula/postgresql.rb
@@ -83,45 +83,45 @@ class Postgresql < Formula
   def post_install
     (var/"log").mkpath
     (var/"postgres").mkpath
-    unless File.exist? "#{var}/postgres/PG_VERSION"
-      system "#{bin}/initdb", "#{var}/postgres"
-    end
+    system "#{bin}/initdb", "#{var}/postgres" unless File.exist? "#{var}/postgres/PG_VERSION"
   end
 
-  def caveats; <<~EOS
-    To migrate existing data from a previous major version of PostgreSQL run:
-      brew postgresql-upgrade-database
-  EOS
+  def caveats
+    <<~EOS
+      To migrate existing data from a previous major version of PostgreSQL run:
+        brew postgresql-upgrade-database
+    EOS
   end
 
-  plist_options :manual => "pg_ctl -D #{HOMEBREW_PREFIX}/var/postgres start"
+  plist_options manual: "pg_ctl -D #{HOMEBREW_PREFIX}/var/postgres start"
 
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-      <key>KeepAlive</key>
-      <true/>
-      <key>Label</key>
-      <string>#{plist_name}</string>
-      <key>ProgramArguments</key>
-      <array>
-        <string>#{opt_bin}/postgres</string>
-        <string>-D</string>
-        <string>#{var}/postgres</string>
-      </array>
-      <key>RunAtLoad</key>
-      <true/>
-      <key>WorkingDirectory</key>
-      <string>#{HOMEBREW_PREFIX}</string>
-      <key>StandardOutPath</key>
-      <string>#{var}/log/#{name}.log</string>
-      <key>StandardErrorPath</key>
-      <string>#{var}/log/#{name}.log</string>
-    </dict>
-    </plist>
-  EOS
+  def plist
+    <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+        <key>KeepAlive</key>
+        <true/>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/postgres</string>
+          <string>-D</string>
+          <string>#{var}/postgres</string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>WorkingDirectory</key>
+        <string>#{HOMEBREW_PREFIX}</string>
+        <key>StandardOutPath</key>
+        <string>#{var}/log/#{name}.log</string>
+        <key>StandardErrorPath</key>
+        <string>#{var}/log/#{name}.log</string>
+      </dict>
+      </plist>
+    EOS
   end
 
   test do
diff --git a/Formula/qt.rb b/Formula/qt.rb
index d643c53..72b3316 100644
--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -7,7 +7,7 @@ class Qt < Formula
   mirror "https://qt.mirror.constant.com/archive/qt/5.11/5.11.1/single/qt-everywhere-src-5.11.1.tar.xz"
   mirror "http://qt.mirrors.tds.net/qt/archive/qt/5.11/5.11.1/single/qt-everywhere-src-5.11.1.tar.xz"
   sha256 "39602cb08f9c96867910c375d783eed00fc4a244bffaa93b801225d17950fb2b"
-  head "https://code.qt.io/qt/qt5.git", :branch => "5.11", :shallow => false
+  head "https://code.qt.io/qt/qt5.git", branch: "5.11", shallow: false
 
   bottle do
     root_url "https://movableink-homebrew-formulas.s3.amazonaws.com"
@@ -22,7 +22,7 @@ class Qt < Formula
   deprecated_option "with-mysql" => "with-mysql-client"
 
   depends_on "pkg-config" => :build
-  depends_on :xcode => :build
+  depends_on xcode: :build
   depends_on "mysql-client" => :optional
   depends_on "postgresql" => :optional
 
@@ -96,10 +96,11 @@ class Qt < Formula
     Pathname.glob("#{bin}/*.app") { |app| mv app, libexec }
   end
 
-  def caveats; <<~EOS
-    We agreed to the Qt open source license for you.
-    If this is unacceptable you should uninstall.
-  EOS
+  def caveats
+    <<~EOS
+      We agreed to the Qt open source license for you.
+      If this is unacceptable you should uninstall.
+    EOS
   end
 
   test do
diff --git a/Formula/qtwebkit.rb b/Formula/qtwebkit.rb
index 98c5c95..08bec85 100644
--- a/Formula/qtwebkit.rb
+++ b/Formula/qtwebkit.rb
@@ -2,24 +2,24 @@ class Qtwebkit < Formula
   desc "Full-featured qt port of the WebKit rendering engine"
   homepage "https://github.com/movableink/webkit"
   url "https://github.com/annulen/webkit/releases/download/qtwebkit-tp4/qtwebkit-tp4.tar.xz"
+  version "HEAD-c0e9b56"
   sha256 "35fcf7e04742b040a072245d79f36d1486e63345a69f53e09408c6564d3bcf27"
   revision 1
-  version "HEAD-c0e9b56"
-  head "https://github.com/movableink/webkit.git", :branch => "macos-include-dir"
+  head "https://github.com/movableink/webkit.git", branch: "macos-include-dir"
+
+  bottle do
+    root_url "https://movableink-homebrew-formulas.s3.amazonaws.com"
+    sha256 cellar: :any, high_sierra: "b6c1a5f275e9bc2a945a97c0c00c88c4fb709c156d44f423893fa1dbc78db446"
+  end
 
   depends_on "cmake" => :build
   depends_on "ninja" => [:build, :optional]
-  depends_on "movableink/formulas/qt"
+  depends_on "fontconfig"
   depends_on "libjpeg"
   depends_on "libpng"
-  depends_on "fontconfig"
+  depends_on "movableink/formulas/qt"
   depends_on "webp"
 
-  bottle do
-    root_url "https://movableink-homebrew-formulas.s3.amazonaws.com"
-    sha256 cellar: :any, high_sierra: "b6c1a5f275e9bc2a945a97c0c00c88c4fb709c156d44f423893fa1dbc78db446"
-  end
-
   def install
     qt5 = Formula["qt5"]
 ```