### PR TITLE
Fix outdated apache spark formula

### DIFF
--- a/Formula/apache-spark.rb
+++ b/Formula/apache-spark.rb
@@ -6,8 +6,6 @@ class ApacheSpark < Formula
   sha256 "e964a28e797707a2924c8d29b0c2f4bca2b58c893b1e3207d70e0cd40dfd2758"
   head "https://github.com/apache/spark.git"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   def install


### PR DESCRIPTION
Installing this tap gives the error:

```
Error: Invalid formula: /opt/homebrew/Library/Taps/movableink/homebrew-formulas/Formula/apache-spark.rb
apache-spark: Calling bottle :unneeded is disabled! There is no replacement.
Please report this issue to the movableink/formulas tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/movableink/homebrew-formulas/Formula/apache-spark.rb:9
```