### PR TITLE
Update NSQ to use multiarch binary

### DIFF
--- a/Formula/nsq.rb
+++ b/Formula/nsq.rb
@@ -2,7 +2,7 @@ class Nsq < Formula
   desc "Realtime distributed messaging platform"
   homepage "https://nsq.io/"
   url "https://movableink-developer-binaries.s3-us-west-2.amazonaws.com/nsq_0.3.8_darwin.zip"
-  sha256 "7ac121e06df0a08b63b646064ec6710ee70e9bde89272ef502ea9b5ae8039bc6"
+  sha256 "70fa07a13dd1d01039bca5ad03b72ee02eaf30da9e291d85e171d3e2a515284c"
 
   depends_on "movableink/formulas/nsqadmin"
   depends_on "movableink/formulas/nsqd"

--- a/Formula/nsq.rb
+++ b/Formula/nsq.rb
@@ -2,7 +2,7 @@ class Nsq < Formula
   desc "Realtime distributed messaging platform"
   homepage "https://nsq.io/"
   url "https://movableink-developer-binaries.s3-us-west-2.amazonaws.com/nsq_0.3.8_darwin.zip"
-  sha256 "70fa07a13dd1d01039bca5ad03b72ee02eaf30da9e291d85e171d3e2a515284c"
+  sha256 "4df0a59b8e82c9502467b94df0ef5135457033751d9ff3239076539e1c6ea22e"
 
   depends_on "movableink/formulas/nsqadmin"
   depends_on "movableink/formulas/nsqd"

--- a/Formula/nsqadmin.rb
+++ b/Formula/nsqadmin.rb
@@ -2,7 +2,7 @@ class Nsqadmin < Formula
   desc "Admin UI for NSQ"
   homepage "https://nsq.io"
   url "https://movableink-developer-binaries.s3-us-west-2.amazonaws.com/nsq_0.3.8_darwin.zip"
-  sha256 "7ac121e06df0a08b63b646064ec6710ee70e9bde89272ef502ea9b5ae8039bc6"
+  sha256 "70fa07a13dd1d01039bca5ad03b72ee02eaf30da9e291d85e171d3e2a515284c"
 
   def install
     bin.install "#{buildpath}/nsqadmin"

--- a/Formula/nsqadmin.rb
+++ b/Formula/nsqadmin.rb
@@ -2,39 +2,17 @@ class Nsqadmin < Formula
   desc "Admin UI for NSQ"
   homepage "https://nsq.io"
   url "https://movableink-developer-binaries.s3-us-west-2.amazonaws.com/nsq_0.3.8_darwin.zip"
-  sha256 "70fa07a13dd1d01039bca5ad03b72ee02eaf30da9e291d85e171d3e2a515284c"
+  sha256 "4df0a59b8e82c9502467b94df0ef5135457033751d9ff3239076539e1c6ea22e"
 
   def install
     bin.install "#{buildpath}/nsqadmin"
   end
 
-  plist_options :startup => true
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>KeepAlive</key>
-        <true/>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{bin}/nsqadmin</string>
-          <string>-lookupd-http-address=127.0.0.1:4161</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>WorkingDirectory</key>
-        <string>#{var}</string>
-        <key>StandardErrorPath</key>
-        <string>#{var}/log/nsqadmin.log</string>
-        <key>StandardOutPath</key>
-        <string>#{var}/log/nsqadmin.log</string>
-      </dict>
-    </plist>
-  EOS
+  service do
+    run [bin/"nsqadmin", "-lookupd-http-address=127.0.0.1:4161"]
+    working_dir var
+    log_path var/"log/nsqadmin.log"
+    error_log_path var/"log/nsqadmin.log"
   end
 
   test do

--- a/Formula/nsqd.rb
+++ b/Formula/nsqd.rb
@@ -2,7 +2,7 @@ class Nsqd < Formula
   desc "Message queueing daemon for NSQ"
   homepage "https://nsq.io"
   url "https://movableink-developer-binaries.s3-us-west-2.amazonaws.com/nsq_0.3.8_darwin.zip"
-  sha256 "7ac121e06df0a08b63b646064ec6710ee70e9bde89272ef502ea9b5ae8039bc6"
+  sha256 "70fa07a13dd1d01039bca5ad03b72ee02eaf30da9e291d85e171d3e2a515284c"
 
   def install
     bin.install "#{buildpath}/nsqd"

--- a/Formula/nsqd.rb
+++ b/Formula/nsqd.rb
@@ -2,7 +2,7 @@ class Nsqd < Formula
   desc "Message queueing daemon for NSQ"
   homepage "https://nsq.io"
   url "https://movableink-developer-binaries.s3-us-west-2.amazonaws.com/nsq_0.3.8_darwin.zip"
-  sha256 "70fa07a13dd1d01039bca5ad03b72ee02eaf30da9e291d85e171d3e2a515284c"
+  sha256 "4df0a59b8e82c9502467b94df0ef5135457033751d9ff3239076539e1c6ea22e"
 
   def install
     bin.install "#{buildpath}/nsqd"
@@ -10,35 +10,16 @@ class Nsqd < Formula
     mkdir "#{var}/nsq"
   end
 
-  plist_options :startup => true
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>KeepAlive</key>
-        <true/>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{bin}/nsqd</string>
-          <string>-data-path=#{var}/nsq</string>
-          <string>-broadcast-address=localhost</string>
-          <string>-lookupd-tcp-address=127.0.0.1:4160</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>WorkingDirectory</key>
-        <string>#{var}</string>
-        <key>StandardErrorPath</key>
-        <string>#{var}/log/nsqd.log</string>
-        <key>StandardOutPath</key>
-        <string>#{var}/log/nsqd.log</string>
-      </dict>
-    </plist>
-  EOS
+  service do
+    run [
+      bin/"nsqd",
+      "-data-path=#{var}/nsq",
+      "-broadcast-address=localhost",
+      "-lookupd-tcp-address=127.0.0.1:4160"
+    ]
+    working_dir var
+    log_path var/"log/nsqd.log"
+    error_log_path var/"log/nsqd.log"
   end
 
   test do

--- a/Formula/nsqlookupd.rb
+++ b/Formula/nsqlookupd.rb
@@ -2,38 +2,17 @@ class Nsqlookupd < Formula
   desc "Topology daemon for NSQ"
   homepage "https://nsq.io"
   url "https://movableink-developer-binaries.s3-us-west-2.amazonaws.com/nsq_0.3.8_darwin.zip"
-  sha256 "70fa07a13dd1d01039bca5ad03b72ee02eaf30da9e291d85e171d3e2a515284c"
+  sha256 "4df0a59b8e82c9502467b94df0ef5135457033751d9ff3239076539e1c6ea22e"
 
   def install
     bin.install "#{buildpath}/nsqlookupd"
   end
 
-  plist_options :startup => true
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>KeepAlive</key>
-        <true/>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{bin}/nsqlookupd</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>WorkingDirectory</key>
-        <string>#{var}</string>
-        <key>StandardErrorPath</key>
-        <string>#{var}/log/nsqlookupd.log</string>
-        <key>StandardOutPath</key>
-        <string>#{var}/log/nsqlookupd.log</string>
-      </dict>
-    </plist>
-  EOS
+  service do
+    run [bin/"nsqlookupd"]
+    working_dir var
+    log_path var/"log/nsqlookupd.log"
+    error_log_path var/"log/nsqlookupd.log"
   end
 
   test do

--- a/Formula/nsqlookupd.rb
+++ b/Formula/nsqlookupd.rb
@@ -2,7 +2,7 @@ class Nsqlookupd < Formula
   desc "Topology daemon for NSQ"
   homepage "https://nsq.io"
   url "https://movableink-developer-binaries.s3-us-west-2.amazonaws.com/nsq_0.3.8_darwin.zip"
-  sha256 "7ac121e06df0a08b63b646064ec6710ee70e9bde89272ef502ea9b5ae8039bc6"
+  sha256 "70fa07a13dd1d01039bca5ad03b72ee02eaf30da9e291d85e171d3e2a515284c"
 
   def install
     bin.install "#{buildpath}/nsqlookupd"

--- a/Formula/nsqutils.rb
+++ b/Formula/nsqutils.rb
@@ -2,7 +2,7 @@ class Nsqutils < Formula
   desc "Utilities for NSQ"
   homepage "https://nsq.io"
   url "https://movableink-developer-binaries.s3-us-west-2.amazonaws.com/nsq_0.3.8_darwin.zip"
-  sha256 "70fa07a13dd1d01039bca5ad03b72ee02eaf30da9e291d85e171d3e2a515284c"
+  sha256 "4df0a59b8e82c9502467b94df0ef5135457033751d9ff3239076539e1c6ea22e"
 
   def install
     bin.install Dir["#{buildpath}/nsq_*"]

--- a/Formula/nsqutils.rb
+++ b/Formula/nsqutils.rb
@@ -2,7 +2,7 @@ class Nsqutils < Formula
   desc "Utilities for NSQ"
   homepage "https://nsq.io"
   url "https://movableink-developer-binaries.s3-us-west-2.amazonaws.com/nsq_0.3.8_darwin.zip"
-  sha256 "7ac121e06df0a08b63b646064ec6710ee70e9bde89272ef502ea9b5ae8039bc6"
+  sha256 "70fa07a13dd1d01039bca5ad03b72ee02eaf30da9e291d85e171d3e2a515284c"
 
   def install
     bin.install Dir["#{buildpath}/nsq_*"]


### PR DESCRIPTION
:house: [ch77441](https://app.clubhouse.io/movableink/story/77441)

Currently our NSQ binaries only support amd64, and the formulas use deprecation functionality.

This updates the SHA of the stored binaries to reference the multiarch binaries that will exist going forward (including amd64 and arm64 support), and updates the service definition to use the updated syntax.

Once this has been approved I will update the zip file in S3 at s3://movableink-developer-binaries/nsq_0.3.8_darwin.zip to the new version.